### PR TITLE
Adding meta.yaml file required for building Conda

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,0 +1,30 @@
+package:
+  name: floweaver
+  version: "2.0.0a3"
+
+source:
+  fn: floweaver-2.0.0a3.tar.gz
+  md5: 979df1406d72ad571794355e0018d5f3
+  url: https://files.pythonhosted.org/packages/11/84/d3b851bb1a7be9d6d6f86d88d36956617cb8029818fba645352da9052b62/floweaver-2.0.0a3.tar.gz
+
+# The commented out section below shows the requirements and test from the
+# tutorial on how to build a conda package from scratch. I wasn't sure what
+# needs to go there. Rest of the file should be good to go. I should be able
+# to build the conda packages presuming the given information is correct.
+#
+# requirements:
+#   host:
+#     - python
+#     - setuptools
+
+#   run:
+#     - python
+
+# test:
+#   imports:
+#     -
+
+about:
+  home: https://github.com/ricklupton/floweaver
+  license: MIT
+  license_file: LICENSE


### PR DESCRIPTION
The commented out section shows the requirements and test from the tutorial on how to build a conda package from scratch. I wasn't sure what needs to go there. Rest of the file should be good to go. I should be able to build the conda packages presuming the given information is correct.

For more information, [here](https://conda.io/docs/user-guide/tutorials/build-pkgs.html) is the tutorial I used.

This [method](https://conda.io/docs/user-guide/tutorials/build-pkgs-skeleton.html) did not work as it returned the following error message.

    macbook-pro:~ alialsabbah1$ conda skeleton pypi floweaver

    Leaving build/test directories:
    Work:
    /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726504858/work 
    Test:
    /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726504858/test_tmp 
    Leaving build/test environments:
    Test:
    source activate  /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726504858/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl 
    Build:
    source activate  /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726504858/_build_env 


    Traceback (most recent call last):
    File "/Users/alialsabbah/miniconda3/bin/conda-skeleton", line 11, in <module>
    sys.exit(main())
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/cli/main_skeleton.py", line 65, in main
    return execute(sys.argv[1:])
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/cli/main_skeleton.py", line 61, in execute
    version=args.version, config=config)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/api.py", line 281, in skeletonize
    recursive=recursive, config=config, **kwargs)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/skeletons/pypi.py", line 224, in skeletonize
    raise RuntimeError("directory already exists: %s" % dir_path)
    RuntimeError: directory already exists: ./floweaver
    macbook-pro:~ alialsabbah1$ conda skeleton pypi floweaver
    Warning, the following versions were found for floweaver
    2.0.0a
    2.0.0a2
    2.0.0a3
    Using 2.0.0a3
    Use --version to specify a different version.
    Using url https://files.pythonhosted.org/packages/11/84/d3b851bb1a7be9d6d6f86d88d36956617cb8029818fba645352da9052b62/floweaver-2.0.0a3.tar.gz (30 KB) for floweaver.
    Downloading floweaver
    PyPI URL:  https://files.pythonhosted.org/packages/11/84/d3b851bb1a7be9d6d6f86d88d36956617cb8029818fba645352da9052b62/floweaver-2.0.0a3.tar.gz
    Using cached download
    Unpacking floweaver...
    done
    working in /var/folders/xg/j3r10lqd3w7gtgmqc0q6hn5h0000gq/T/tmpni7bubl_conda_skeleton_floweaver-2.0.0a3.tar.gz
    Solving environment: ...working... done

    ## Package Plan ##

    environment location: /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726550439/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_place


    The following NEW packages will be INSTALLED:

    ca-certificates: 2018.03.07-0           
    certifi:         2018.4.16-py36_0       
    libcxx:          4.0.1-h579ed51_0       
    libcxxabi:       4.0.1-hebd6815_0       
    libedit:         3.1.20170329-hb402a30_2
    libffi:          3.2.1-h475c297_4       
    ncurses:         6.1-h0a44026_0         
    openssl:         1.0.2o-h26aff7b_0      
    pip:             10.0.1-py36_0          
    python:          3.6.6-hc167b69_0       
    pyyaml:          3.13-py36h1de35cc_0    
    readline:        7.0-hc1231fa_4         
    setuptools:      39.2.0-py36_0          
    sqlite:          3.24.0-ha441bb4_0      
    tk:              8.6.7-h35a86e2_3       
    wheel:           0.31.1-py36_0          
    xz:              5.2.4-h1de35cc_4       
    yaml:            0.1.7-hc338f04_2       
    zlib:            1.2.11-hf3cbc9b_2      

    Preparing transaction: ...working... done
    Verifying transaction: ...working... done
    Executing transaction: ...working... done
    Applying patch: '/var/folders/xg/j3r10lqd3w7gtgmqc0q6hn5h0000gq/T/tmpni7bubl_conda_skeleton_floweaver-2.0.0a3.tar.gz/pypi-distutils.patch'
    Trying to apply patch as-is
    INFO:conda_build.source:Trying to apply patch as-is
    patching file core.py
    Hunk #1 succeeded at 168 with fuzz 2 (offset 1 line).

    Leaving build/test directories:
    Work:
    /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726550439/work 
    Test:
    /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726550439/test_tmp 
    Leaving build/test environments:
    Test:
    source activate  /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726550439/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl 
    Build:
    source activate  /Users/alialsabbah/miniconda3/conda-bld/skeleton_1532726550439/_build_env 


    Traceback (most recent call last):
    File "/Users/alialsabbah/miniconda3/bin/conda-skeleton", line 11, in <module>
    sys.exit(main())
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/cli/main_skeleton.py", line 65, in main
    return execute(sys.argv[1:])
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/cli/main_skeleton.py", line 61, in execute
    version=args.version, config=config)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/api.py", line 281, in skeletonize
    recursive=recursive, config=config, **kwargs)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/skeletons/pypi.py", line 290, in skeletonize
    setup_options=setup_options)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/skeletons/pypi.py", line 762, in get_package_metadata
    dep, marker = parse_dep_with_env_marker(dep)
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/skeletons/pypi.py", line 677, in parse_dep_with_env_marker
    match.group("env_mark_constraint"))
    File "/Users/alialsabbah/miniconda3/lib/python3.6/site-packages/conda_build/skeletons/pypi.py", line 664, in env_mark_lookup
    marker = " ".join((env_mark_table[env_mark_name]["repl"],
    KeyError: '('